### PR TITLE
Add elm-audio example

### DIFF
--- a/examples/elm-audio/README.md
+++ b/examples/elm-audio/README.md
@@ -1,0 +1,65 @@
+# elm-audio
+
+**Note that this is for example purposes. I've updated port names to match the elm-pkg-js style but some documentation and linked examples are out of date.**
+
+This package explores the following question:
+
+*What if we could play music and sound effects the same way we render HTML?*
+
+To do that, elm-audio adds a `audio` field to your app. It looks something like this:
+```elm
+audio : Model -> Audio
+audio model =
+    if model.soundOn then
+        Audio.audio model.music model.musicStartTime
+    else
+        Audio.silence
+
+main = 
+    Audio.elementWithAudio
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        , audio = audio
+        -- Since this is a normal Elm package we need ports to make this all work
+        , audioPorts = audioPorts
+        }
+```
+
+Notice that we don't need to write code to explicitly start and stop our music. We just say what should be playing and when.
+
+### Getting Started
+
+Make sure you install `ianmackenzie/elm-units` and `elm/time` as this package uses [`Duration`](https://package.elm-lang.org/packages/ianmackenzie/elm-units/latest/Duration#Duration) and [`Posix`](https://package.elm-lang.org/packages/elm/time/latest/Time#Posix) throughout the API.
+
+Here is a simple [example app](https://ellie-app.com/8Nh85ghZWQ5a1) (source code is also [here](https://github.com/MartinSStewart/elm-audio/tree/master/example)) that's a good starting point if you want to begin making something with `elm-audio`.
+
+If you want to see a more interesting use case, I rewrote the audio system in [elm-mogee](https://github.com/MartinSStewart/elm-mogee/tree/elm-audio) to use `elm-audio`.
+
+### JS Setup
+
+The following ports must be defined.
+
+```elm
+-- The ports must have these specifc names.
+port martinsstewart_elm_audio_to_js : Json.Encode.Value -> Cmd msg
+port martinsstewart_elm_audio_from_js : (Json.Decode.Value -> msg) -> Sub msg
+
+main = 
+    Audio.elementWithAudio
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        , audio = audio
+        , audioPort = { toJS = martinsstewart_elm_audio_to_js, fromJS = martinsstewart_elm_audio_from_js }
+        }
+```
+
+Then you'll need to copy the following JS code into your program and then call `startAudio(myElmApp);` (look at the [example app](https://github.com/MartinSStewart/elm-audio/blob/master/example/index.html) if you're not sure about this).
+
+```javascript
+function startAudio(e){if(window.AudioContext=window.AudioContext||window.webkitAudioContext||!1,window.AudioContext){let u=[],s=new AudioContext,d={},l=528;function o(o,t){let n=new XMLHttpRequest;n.open("GET",o,!0),n.responseType="arraybuffer",n.onerror=function(){e.ports.martinsstewart_elm_audio_from_js.send({type:0,requestId:t,error:"NetworkError"})},n.onload=function(){s.decodeAudioData(n.response,function(n){let r=u.length,a=o.endsWith(".mp3");u.push({isMp3:a,buffer:n}),e.ports.martinsstewart_elm_audio_from_js.send({type:1,requestId:t,bufferId:r,durationInSeconds:(n.length-(a?l:0))/n.sampleRate})},function(o){e.ports.martinsstewart_elm_audio_from_js.send({type:0,requestId:t,error:o.message})})},n.send()}function t(e,o){return(e-o)/1e3+s.currentTime}function n(e,o,t){o?(e.loopStart=t+o.loopStart/1e3,e.loopEnd=t+o.loopEnd/1e3,e.loop=!0):e.loop=!1}function r(e,o){return e.map(e=>{let n=s.createGain();n.gain.setValueAtTime(e[0].volume,0),n.gain.linearRampToValueAtTime(e[0].volume,t(e[0].time,o));for(let r=1;r<e.length;r++){let a=e[r],i=e[r-1],u=t(a.time,o);if(u>=s.currentTime&&i.contextTime<s.currentTime){let e=(s.currentTime-i.contextTime)/(u-i.contextTime)*(a.volume-i.volume)+i.volume;isFinite(e)&&n.gain.setValueAtTime(e,0)}else u>=s.currentTime?n.gain.linearRampToValueAtTime(a.volume,u):n.gain.setValueAtTime(a.volume,0);i={contextTime:u,volume:a.volume}}return n})}function a(e){for(let o=1;o<e.length;o++)e[o-1].connect(e[o])}function i(e,o,i,u,d,m,c,p){let f=e.buffer,b=e.isMp3?l/s.sampleRate:0,T=s.createBufferSource();T.buffer=f,T.playbackRate.value=p,n(T,c,b);let g=r(i,m),A=s.createGain();if(A.gain.setValueAtTime(o,0),a([T,A,...g,s.destination]),u>=m)T.start(t(u,m),b+d/1e3);else{let e=(m-u)/1e3;T.start(0,e+b+d/1e3)}return{sourceNode:T,gainNode:A,volumeAtGainNodes:g}}e.ports.martinsstewart_elm_audio_from_js.send({type:2,samplesPerSecond:s.sampleRate}),e.ports.martinsstewart_elm_audio_to_js.subscribe(e=>{let t=(new Date).getTime();for(let o=0;o<e.audio.length;o++){let m=e.audio[o];switch(m.action){case"stopSound":{let e=d[m.nodeGroupId];d[m.nodeGroupId]=null,e.nodes.sourceNode.stop(),e.nodes.sourceNode.disconnect(),e.nodes.gainNode.disconnect(),e.nodes.volumeAtGainNodes.map(e=>e.disconnect());break}case"setVolume":d[m.nodeGroupId].nodes.gainNode.gain.setValueAtTime(m.volume,0);break;case"setVolumeAt":{let e=d[m.nodeGroupId];e.nodes.volumeAtGainNodes.map(e=>e.disconnect()),e.nodes.gainNode.disconnect();let o=r(m.volumeAt,t);a([e.nodes.gainNode,...o,s.destination]),e.nodes.volumeAtGainNodes=o;break}case"setLoopConfig":{let e=d[m.nodeGroupId],o=u[e.bufferId].isMp3?l/s.sampleRate:0;n(e.nodes.sourceNode,e.loop,o);break}case"setPlaybackRate":d[m.nodeGroupId].nodes.sourceNode.playbackRate.setValueAtTime(m.playbackRate,0);break;case"startSound":{let e=i(u[m.bufferId],m.volume,m.volumeTimelines,m.startTime,m.startAt,t,m.loop,m.playbackRate);d[m.nodeGroupId]={bufferId:m.bufferId,nodes:e};break}}}for(let t=0;t<e.audioCmds.length;t++)o(e.audioCmds[t].audioUrl,e.audioCmds[t].requestId)})}else console.log("Web audio is not supported in your browser.")}
+```
+Unminified version can be found [here](https://github.com/MartinSStewart/elm-audio/blob/master/src/audio.js).

--- a/examples/elm-audio/elm.json
+++ b/examples/elm-audio/elm.json
@@ -1,0 +1,25 @@
+{
+    "type": "package",
+    "name": "MartinSStewart/elm-audio",
+    "summary": "Play sound effects and music in a declarative way",
+    "license": "BSD-3-Clause",
+    "version": "3.0.3",
+    "exposed-modules": [
+        "Audio"
+    ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/browser": "1.0.2 <= v < 2.0.0",
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
+        "elm/time": "1.0.0 <= v < 2.0.0",
+        "elm/url": "1.0.0 <= v < 2.0.0",
+        "ianmackenzie/elm-units": "2.5.0 <= v < 3.0.0",
+        "mgold/elm-nonempty-list": "4.1.0 <= v < 5.0.0"
+    },
+    "test-dependencies": {
+        "elm/random": "1.0.0 <= v < 2.0.0",
+        "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+    }
+}

--- a/examples/elm-audio/src/Audio.elm
+++ b/examples/elm-audio/src/Audio.elm
@@ -1,0 +1,1056 @@
+module Audio exposing
+    ( elementWithAudio, documentWithAudio, applicationWithAudio, Model, Msg
+    , AudioCmd, loadAudio, LoadError(..), Source, cmdMap, cmdBatch, cmdNone
+    , Audio, audio, group, silence, audioWithConfig, audioDefaultConfig, PlayAudioConfig, LoopConfig
+    , scaleVolume, scaleVolumeAt
+    , lamderaFrontendWithAudio, migrateModel, migrateMsg
+    )
+
+{-|
+
+
+# Applications
+
+Create an Elm app that supports playing audio.
+
+@docs elementWithAudio, documentWithAudio, applicationWithAudio, Model, Msg
+
+
+# Load audio
+
+Load audio so you can later play it.
+
+@docs AudioCmd, loadAudio, LoadError, Source, cmdMap, cmdBatch, cmdNone
+
+
+# Play audio
+
+Define what audio should be playing.
+
+@docs Audio, audio, group, silence, audioWithConfig, audioDefaultConfig, PlayAudioConfig, LoopConfig
+
+
+# Audio effects
+
+Effects you can apply to `Audio`.
+
+@docs scaleVolume, scaleVolumeAt
+
+
+# Lamdera stuff
+
+WIP support for Lamdera. Ignore this for now.
+
+@docs lamderaFrontendWithAudio, migrateModel, migrateMsg
+
+-}
+
+import Browser
+import Browser.Navigation exposing (Key)
+import Dict exposing (Dict)
+import Duration exposing (Duration)
+import Html exposing (Html)
+import Json.Decode as JD
+import Json.Encode as JE
+import List.Nonempty as Nonempty exposing (Nonempty)
+import Quantity exposing (Quantity, Rate, Unitless)
+import Time
+import Url exposing (Url)
+
+
+{-| -}
+type Model userMsg userModel
+    = Model (Model_ userMsg userModel)
+
+
+type alias NodeGroupId =
+    Int
+
+
+type alias Model_ userMsg userModel =
+    { audioState : Dict NodeGroupId FlattenedAudio
+    , nodeGroupIdCounter : Int
+    , userModel : userModel
+    , requestCount : Int
+    , pendingRequests : Dict Int (AudioLoadRequest_ userMsg)
+    , samplesPerSecond : Maybe Int
+    }
+
+
+{-| -}
+type Msg userMsg
+    = FromJSMsg FromJSMsg
+    | UserMsg userMsg
+
+
+type FromJSMsg
+    = AudioLoadSuccess { requestId : Int, bufferId : BufferId, duration : Duration }
+    | AudioLoadFailed { requestId : Int, error : LoadError }
+    | InitAudioContext { samplesPerSecond : Int }
+    | JsonParseError { error : String }
+
+
+type alias AudioLoadRequest_ userMsg =
+    { userMsg : Nonempty ( Result LoadError Source, userMsg ), audioUrl : String }
+
+
+{-| An audio command.
+-}
+type AudioCmd userMsg
+    = AudioLoadRequest (AudioLoadRequest_ userMsg)
+    | AudioCmdGroup (List (AudioCmd userMsg))
+
+
+{-| Combine multiple commands into a single command. Conceptually the same as Cmd.batch.
+-}
+cmdBatch : List (AudioCmd userMsg) -> AudioCmd userMsg
+cmdBatch audioCmds =
+    AudioCmdGroup audioCmds
+
+
+{-| A command that does nothing. Conceptually the same as Cmd.none.
+-}
+cmdNone : AudioCmd msg
+cmdNone =
+    AudioCmdGroup []
+
+
+{-| Map a command from one type to another. Conceptually the same as Cmd.map
+-}
+cmdMap : (a -> b) -> AudioCmd a -> AudioCmd b
+cmdMap map cmd =
+    case cmd of
+        AudioLoadRequest audioLoadRequest_ ->
+            mapAudioLoadRequest map audioLoadRequest_
+                |> AudioLoadRequest
+
+        AudioCmdGroup audioCmds ->
+            audioCmds |> List.map (cmdMap map) |> AudioCmdGroup
+
+
+mapAudioLoadRequest : (a -> b) -> AudioLoadRequest_ a -> AudioLoadRequest_ b
+mapAudioLoadRequest mapFunc audioLoadRequest =
+    { userMsg = Nonempty.map (Tuple.mapSecond mapFunc) audioLoadRequest.userMsg
+    , audioUrl = audioLoadRequest.audioUrl
+    }
+
+
+{-| Ports that allows this package to communicate with the JS portion of the package.
+-}
+type alias Ports msg =
+    { toJS : JE.Value -> Cmd (Msg msg), fromJS : (JD.Value -> Msg msg) -> Sub (Msg msg) }
+
+
+getUserModel : Model userMsg userModel -> userModel
+getUserModel (Model model) =
+    model.userModel
+
+
+{-| Browser.element but with the ability to play sounds.
+-}
+elementWithAudio :
+    { init : flags -> ( model, Cmd msg, AudioCmd msg )
+    , view : model -> Html msg
+    , update : msg -> model -> ( model, Cmd msg, AudioCmd msg )
+    , subscriptions : model -> Sub msg
+    , audio : model -> Audio
+    , audioPort : Ports msg
+    }
+    -> Platform.Program flags (Model msg model) (Msg msg)
+elementWithAudio app =
+    { init = app.init >> initHelper app.audioPort.toJS app.audio
+    , view = getUserModel >> app.view >> Html.map UserMsg
+    , update = update app
+    , subscriptions = subscriptions app
+    }
+        |> Browser.element
+
+
+{-| Browser.document but with the ability to play sounds.
+-}
+documentWithAudio :
+    { init : flags -> ( model, Cmd msg, AudioCmd msg )
+    , view : model -> Browser.Document msg
+    , update : msg -> model -> ( model, Cmd msg, AudioCmd msg )
+    , subscriptions : model -> Sub msg
+    , audio : model -> Audio
+    , audioPort : Ports msg
+    }
+    -> Platform.Program flags (Model msg model) (Msg msg)
+documentWithAudio app =
+    { init = app.init >> initHelper app.audioPort.toJS app.audio
+    , view =
+        \model ->
+            let
+                { title, body } =
+                    app.view (getUserModel model)
+            in
+            { title = title
+            , body = body |> List.map (Html.map UserMsg)
+            }
+    , update = update app
+    , subscriptions = subscriptions app
+    }
+        |> Browser.document
+
+
+{-| Browser.application but with the ability to play sounds.
+-}
+applicationWithAudio :
+    { init : flags -> Url -> Key -> ( model, Cmd msg, AudioCmd msg )
+    , view : model -> Browser.Document msg
+    , update : msg -> model -> ( model, Cmd msg, AudioCmd msg )
+    , subscriptions : model -> Sub msg
+    , onUrlRequest : Browser.UrlRequest -> msg
+    , onUrlChange : Url -> msg
+    , audio : model -> Audio
+    , audioPort : Ports msg
+    }
+    -> Platform.Program flags (Model msg model) (Msg msg)
+applicationWithAudio app =
+    { init = \flags url key -> app.init flags url key |> initHelper app.audioPort.toJS app.audio
+    , view =
+        \model ->
+            let
+                { title, body } =
+                    app.view (getUserModel model)
+            in
+            { title = title
+            , body = body |> List.map (Html.map UserMsg)
+            }
+    , update = update app
+    , subscriptions = subscriptions app
+    , onUrlRequest = app.onUrlRequest >> UserMsg
+    , onUrlChange = app.onUrlChange >> UserMsg
+    }
+        |> Browser.application
+
+
+{-| Lamdera.frontend but with the ability to play sounds (highly experimental, just ignore this for now).
+-}
+lamderaFrontendWithAudio :
+    { init : Url.Url -> Browser.Navigation.Key -> ( model, Cmd frontendMsg, AudioCmd frontendMsg )
+    , view : model -> Browser.Document frontendMsg
+    , update : frontendMsg -> model -> ( model, Cmd frontendMsg, AudioCmd frontendMsg )
+    , updateFromBackend : toFrontend -> model -> ( model, Cmd frontendMsg, AudioCmd frontendMsg )
+    , subscriptions : model -> Sub frontendMsg
+    , onUrlRequest : Browser.UrlRequest -> frontendMsg
+    , onUrlChange : Url -> frontendMsg
+    , audio : model -> Audio
+    , audioPort : Ports frontendMsg
+    }
+    ->
+        { init : Url.Url -> Browser.Navigation.Key -> ( Model frontendMsg model, Cmd (Msg frontendMsg) )
+        , view : Model frontendMsg model -> Browser.Document (Msg frontendMsg)
+        , update : Msg frontendMsg -> Model frontendMsg model -> ( Model frontendMsg model, Cmd (Msg frontendMsg) )
+        , updateFromBackend : toFrontend -> Model frontendMsg model -> ( Model frontendMsg model, Cmd (Msg frontendMsg) )
+        , subscriptions : Model frontendMsg model -> Sub (Msg frontendMsg)
+        , onUrlRequest : Browser.UrlRequest -> Msg frontendMsg
+        , onUrlChange : Url -> Msg frontendMsg
+        }
+lamderaFrontendWithAudio app =
+    { init = \url key -> initHelper app.audioPort.toJS app.audio (app.init url key)
+    , view =
+        \model ->
+            let
+                { title, body } =
+                    app.view (getUserModel model)
+            in
+            { title = title
+            , body = body |> List.map (Html.map UserMsg)
+            }
+    , update = update app
+    , updateFromBackend =
+        \toFrontend model ->
+            updateHelper app.audioPort.toJS app.audio (app.updateFromBackend toFrontend) model
+    , subscriptions = subscriptions app
+    , onUrlRequest = app.onUrlRequest >> UserMsg
+    , onUrlChange = app.onUrlChange >> UserMsg
+    }
+
+
+{-| Use this function when migrating your model in Lamdera.
+-}
+migrateModel :
+    (msgOld -> msgNew)
+    -> (modelOld -> ( modelNew, Cmd msgNew ))
+    -> Model msgOld modelOld
+    -> ( Model msgNew modelNew, Cmd msgNew )
+migrateModel msgMigrate modelMigrate (Model model) =
+    let
+        ( newModel, cmd ) =
+            modelMigrate model.userModel
+    in
+    ( Model
+        { userModel = newModel
+        , nodeGroupIdCounter = model.nodeGroupIdCounter
+        , samplesPerSecond = model.samplesPerSecond
+        , audioState = model.audioState
+        , pendingRequests = Dict.map (\_ value -> mapAudioLoadRequest msgMigrate value) model.pendingRequests
+        , requestCount = model.requestCount
+        }
+    , cmd
+    )
+
+
+{-| Use this function when migrating messages in Lamdera.
+-}
+migrateMsg : (msgOld -> ( msgNew, Cmd msgNew )) -> Msg msgOld -> ( Msg msgNew, Cmd msgNew )
+migrateMsg msgMigrate msg =
+    case msg of
+        FromJSMsg fromJSMsg ->
+            ( FromJSMsg fromJSMsg, Cmd.none )
+
+        UserMsg userMsg ->
+            msgMigrate userMsg |> Tuple.mapFirst UserMsg
+
+
+{-| Set the user state stored in `Model`. Useful for dealing with migrations in Lamdera.
+-}
+withUserModel : userModelNew -> Model userMsg userModelOld -> Model userMsg userModelNew
+withUserModel userModel_ (Model model) =
+    { userModel = userModel_
+    , nodeGroupIdCounter = model.nodeGroupIdCounter
+    , samplesPerSecond = model.samplesPerSecond
+    , audioState = model.audioState
+    , pendingRequests = model.pendingRequests
+    , requestCount = model.requestCount
+    }
+        |> Model
+
+
+{-| Change the `userMsg` type in `Model`. Useful for dealing with migrations in Lamdera.
+-}
+mapUserMsg : (userMsgOld -> userMsgNew) -> Model userMsgOld userModel -> Model userMsgNew userModel
+mapUserMsg map (Model model) =
+    { userModel = model.userModel
+    , nodeGroupIdCounter = model.nodeGroupIdCounter
+    , samplesPerSecond = model.samplesPerSecond
+    , audioState = model.audioState
+    , pendingRequests =
+        model.pendingRequests
+            |> Dict.map
+                (\_ { userMsg, audioUrl } ->
+                    { userMsg = Nonempty.map (Tuple.mapSecond map) userMsg
+                    , audioUrl = audioUrl
+                    }
+                )
+    , requestCount = model.requestCount
+    }
+        |> Model
+
+
+updateHelper :
+    (JD.Value -> Cmd (Msg userMsg))
+    -> (userModel -> Audio)
+    -> (userModel -> ( userModel, Cmd userMsg, AudioCmd userMsg ))
+    -> Model userMsg userModel
+    -> ( Model userMsg userModel, Cmd (Msg userMsg) )
+updateHelper audioPort audioFunc userUpdate (Model model) =
+    let
+        ( newUserModel, userCmd, audioCmds ) =
+            userUpdate model.userModel
+
+        ( audioState, newNodeGroupIdCounter, json ) =
+            diffAudioState model.nodeGroupIdCounter model.audioState (audioFunc newUserModel)
+
+        newModel : Model userMsg userModel
+        newModel =
+            Model
+                { model
+                    | audioState = audioState
+                    , nodeGroupIdCounter = newNodeGroupIdCounter
+                    , userModel = newUserModel
+                }
+
+        ( newModel2, audioRequests ) =
+            audioCmds |> encodeAudioCmd newModel
+
+        portMessage =
+            JE.object
+                [ ( "audio", JE.list identity json )
+                , ( "audioCmds", audioRequests )
+                ]
+    in
+    ( newModel2
+    , Cmd.batch [ Cmd.map UserMsg userCmd, audioPort portMessage ]
+    )
+
+
+initHelper :
+    (JD.Value -> Cmd (Msg userMsg))
+    -> (model -> Audio)
+    -> ( model, Cmd userMsg, AudioCmd userMsg )
+    -> ( Model userMsg model, Cmd (Msg userMsg) )
+initHelper audioPort audioFunc ( model, cmds, audioCmds ) =
+    let
+        ( audioState, newNodeGroupIdCounter, json ) =
+            diffAudioState 0 Dict.empty (audioFunc model)
+
+        initialModel =
+            Model
+                { audioState = audioState
+                , nodeGroupIdCounter = newNodeGroupIdCounter
+                , userModel = model
+                , requestCount = 0
+                , pendingRequests = Dict.empty
+                , samplesPerSecond = Nothing
+                }
+
+        ( initialModel2, audioRequests ) =
+            audioCmds |> encodeAudioCmd initialModel
+
+        portMessage : JE.Value
+        portMessage =
+            JE.object
+                [ ( "audio", JE.list identity json )
+                , ( "audioCmds", audioRequests )
+                ]
+    in
+    ( initialModel2
+    , Cmd.batch [ Cmd.map UserMsg cmds, audioPort portMessage ]
+    )
+
+
+{-| Borrowed from List.Extra so we don't need to depend on the entire package.
+-}
+find : (a -> Bool) -> List a -> Maybe a
+find predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        first :: rest ->
+            if predicate first then
+                Just first
+
+            else
+                find predicate rest
+
+
+{-| Borrowed from List.Extra so we don't need to depend on the entire package.
+-}
+removeAt : Int -> List a -> List a
+removeAt index l =
+    if index < 0 then
+        l
+
+    else
+        let
+            head =
+                List.take index l
+
+            tail =
+                List.drop index l |> List.tail
+        in
+        case tail of
+            Nothing ->
+                l
+
+            Just t ->
+                List.append head t
+
+
+update :
+    { a
+        | audioPort : Ports userMsg
+        , audio : userModel -> Audio
+        , update : userMsg -> userModel -> ( userModel, Cmd userMsg, AudioCmd userMsg )
+    }
+    -> Msg userMsg
+    -> Model userMsg userModel
+    -> ( Model userMsg userModel, Cmd (Msg userMsg) )
+update app msg (Model model) =
+    case msg of
+        UserMsg userMsg ->
+            updateHelper app.audioPort.toJS app.audio (app.update userMsg) (Model model)
+
+        FromJSMsg response ->
+            case response of
+                AudioLoadSuccess { requestId, bufferId, duration } ->
+                    case Dict.get requestId model.pendingRequests of
+                        Just pendingRequest ->
+                            let
+                                a =
+                                    { bufferId = bufferId } |> File |> Ok
+
+                                b =
+                                    Nonempty.toList pendingRequest.userMsg |> find (Tuple.first >> (==) a)
+                            in
+                            case b of
+                                Just ( _, userMsg ) ->
+                                    { model | pendingRequests = Dict.remove requestId model.pendingRequests }
+                                        |> Model
+                                        |> updateHelper
+                                            app.audioPort.toJS
+                                            app.audio
+                                            (app.update userMsg)
+
+                                Nothing ->
+                                    { model | pendingRequests = Dict.remove requestId model.pendingRequests }
+                                        |> Model
+                                        |> updateHelper
+                                            app.audioPort.toJS
+                                            app.audio
+                                            (Nonempty.head pendingRequest.userMsg |> Tuple.second |> app.update)
+
+                        Nothing ->
+                            ( Model model, Cmd.none )
+
+                AudioLoadFailed { requestId, error } ->
+                    case Dict.get requestId model.pendingRequests of
+                        Just pendingRequest ->
+                            let
+                                a =
+                                    Err error
+
+                                b =
+                                    Nonempty.toList pendingRequest.userMsg |> find (Tuple.first >> (==) a)
+                            in
+                            case b of
+                                Just ( _, userMsg ) ->
+                                    { model | pendingRequests = Dict.remove requestId model.pendingRequests }
+                                        |> Model
+                                        |> updateHelper
+                                            app.audioPort.toJS
+                                            app.audio
+                                            (app.update userMsg)
+
+                                Nothing ->
+                                    { model | pendingRequests = Dict.remove requestId model.pendingRequests }
+                                        |> Model
+                                        |> updateHelper
+                                            app.audioPort.toJS
+                                            app.audio
+                                            (Nonempty.head pendingRequest.userMsg |> Tuple.second |> app.update)
+
+                        Nothing ->
+                            ( Model model, Cmd.none )
+
+                InitAudioContext { samplesPerSecond } ->
+                    ( Model { model | samplesPerSecond = Just samplesPerSecond }, Cmd.none )
+
+                JsonParseError { error } ->
+                    ( Model model, Cmd.none )
+
+
+subscriptions :
+    { a | subscriptions : userModel -> Sub userMsg, audioPort : Ports userMsg }
+    -> Model userMsg userModel
+    -> Sub (Msg userMsg)
+subscriptions app (Model model) =
+    Sub.batch [ app.subscriptions model.userModel |> Sub.map UserMsg, app.audioPort.fromJS fromJSPortSub ]
+
+
+decodeLoadError =
+    JD.string
+        |> JD.andThen
+            (\value ->
+                case value of
+                    "NetworkError" ->
+                        JD.succeed NetworkError
+
+                    "MediaDecodeAudioDataUnknownContentType" ->
+                        JD.succeed MediaDecodeAudioDataUnknownContentType
+
+                    _ ->
+                        JD.fail "Unknown load error"
+            )
+
+
+decodeFromJSMsg =
+    JD.field "type" JD.int
+        |> JD.andThen
+            (\value ->
+                case value of
+                    0 ->
+                        JD.map2 (\requestId error -> AudioLoadFailed { requestId = requestId, error = error })
+                            (JD.field "requestId" JD.int)
+                            (JD.field "error" decodeLoadError)
+
+                    1 ->
+                        JD.map3
+                            (\requestId bufferId duration ->
+                                AudioLoadSuccess
+                                    { requestId = requestId
+                                    , bufferId = bufferId
+                                    , duration = Duration.seconds duration
+                                    }
+                            )
+                            (JD.field "requestId" JD.int)
+                            (JD.field "bufferId" decodeBufferId)
+                            (JD.field "durationInSeconds" JD.float)
+
+                    2 ->
+                        JD.map (\samplesPerSecond -> InitAudioContext { samplesPerSecond = samplesPerSecond })
+                            (JD.field "samplesPerSecond" JD.int)
+
+                    _ ->
+                        JsonParseError { error = "Type " ++ String.fromInt value ++ " not handled." } |> JD.succeed
+            )
+
+
+fromJSPortSub : JD.Value -> Msg userMsg
+fromJSPortSub json =
+    case JD.decodeValue decodeFromJSMsg json of
+        Ok value ->
+            FromJSMsg value
+
+        Err error ->
+            FromJSMsg (JsonParseError { error = JD.errorToString error })
+
+
+type BufferId
+    = BufferId Int
+
+
+encodeBufferId (BufferId bufferId) =
+    JE.int bufferId
+
+
+decodeBufferId =
+    JD.int |> JD.map BufferId
+
+
+updateAudioState :
+    ( NodeGroupId, FlattenedAudio )
+    -> ( List FlattenedAudio, Dict NodeGroupId FlattenedAudio, List JE.Value )
+    -> ( List FlattenedAudio, Dict NodeGroupId FlattenedAudio, List JE.Value )
+updateAudioState ( nodeGroupId, audioGroup ) ( flattenedAudio, audioState, json ) =
+    let
+        validAudio : List ( Int, FlattenedAudio )
+        validAudio =
+            flattenedAudio
+                |> List.indexedMap Tuple.pair
+                |> List.filter
+                    (\( _, a ) ->
+                        (a.source == audioGroup.source)
+                            && (a.startTime == audioGroup.startTime)
+                            && (a.startAt == audioGroup.startAt)
+                    )
+    in
+    case find (\( _, a ) -> a == audioGroup) validAudio of
+        Just ( index, _ ) ->
+            -- We found a perfect match so nothing needs to change.
+            ( removeAt index flattenedAudio, audioState, json )
+
+        Nothing ->
+            case validAudio of
+                ( index, a ) :: _ ->
+                    let
+                        encodeValue getter encoder =
+                            if getter audioGroup == getter a then
+                                Nothing
+
+                            else
+                                encoder nodeGroupId (getter a) |> Just
+
+                        effects =
+                            [ encodeValue .volume encodeSetVolume
+                            , encodeValue .loop encodeSetLoopConfig
+                            , encodeValue .playbackRate encodeSetPlaybackRate
+                            , encodeValue .volumeTimelines encodeSetVolumeAt
+                            ]
+                                |> List.filterMap identity
+                    in
+                    -- We found audio that has the same bufferId and startTime but some other settings have changed.
+                    ( removeAt index flattenedAudio
+                    , Dict.insert nodeGroupId a audioState
+                    , effects ++ json
+                    )
+
+                [] ->
+                    -- We didn't find any audio with the same bufferId and startTime so we'll stop this sound.
+                    ( flattenedAudio
+                    , Dict.remove nodeGroupId audioState
+                    , encodeStopSound nodeGroupId :: json
+                    )
+
+
+diffAudioState : Int -> Dict NodeGroupId FlattenedAudio -> Audio -> ( Dict NodeGroupId FlattenedAudio, Int, List JE.Value )
+diffAudioState nodeGroupIdCounter audioState newAudio =
+    let
+        ( newAudioLeft, newAudioState, json2 ) =
+            Dict.toList audioState
+                |> List.foldl updateAudioState
+                    ( flattenAudio newAudio, audioState, [] )
+
+        ( newNodeGroupIdCounter, newAudioState2, json3 ) =
+            newAudioLeft
+                |> List.foldl
+                    (\audioLeft ( counter, audioState_, json_ ) ->
+                        ( counter + 1
+                        , Dict.insert counter audioLeft audioState_
+                        , encodeStartSound counter audioLeft :: json_
+                        )
+                    )
+                    ( nodeGroupIdCounter, newAudioState, json2 )
+    in
+    ( newAudioState2, newNodeGroupIdCounter, json3 )
+
+
+encodeStartSound : NodeGroupId -> FlattenedAudio -> JE.Value
+encodeStartSound nodeGroupId audio_ =
+    JE.object
+        [ ( "action", JE.string "startSound" )
+        , ( "nodeGroupId", JE.int nodeGroupId )
+        , ( "bufferId", audioSourceBufferId audio_.source |> encodeBufferId )
+        , ( "startTime", audio_.startTime |> encodeTime )
+        , ( "startAt", audio_.startAt |> encodeDuration )
+        , ( "volume", JE.float audio_.volume )
+        , ( "volumeTimelines", JE.list encodeVolumeTimeline audio_.volumeTimelines )
+        , ( "loop", encodeLoopConfig audio_.loop )
+        , ( "playbackRate", JE.float audio_.playbackRate )
+        ]
+
+
+encodeTime : Time.Posix -> JE.Value
+encodeTime =
+    Time.posixToMillis >> JE.int
+
+
+encodeDuration : Duration -> JE.Value
+encodeDuration =
+    Duration.inMilliseconds >> JE.float
+
+
+encodeStopSound : NodeGroupId -> JE.Value
+encodeStopSound nodeGroupId =
+    JE.object
+        [ ( "action", JE.string "stopSound" )
+        , ( "nodeGroupId", JE.int nodeGroupId )
+        ]
+
+
+encodeSetVolume : NodeGroupId -> Float -> JE.Value
+encodeSetVolume nodeGroupId volume =
+    JE.object
+        [ ( "nodeGroupId", JE.int nodeGroupId )
+        , ( "action", JE.string "setVolume" )
+        , ( "volume", JE.float volume )
+        ]
+
+
+encodeSetLoopConfig : NodeGroupId -> Maybe LoopConfig -> JE.Value
+encodeSetLoopConfig nodeGroupId loop =
+    JE.object
+        [ ( "nodeGroupId", JE.int nodeGroupId )
+        , ( "action", JE.string "setLoopConfig" )
+        , ( "loop", encodeLoopConfig loop )
+        ]
+
+
+encodeSetPlaybackRate : NodeGroupId -> Float -> JE.Value
+encodeSetPlaybackRate nodeGroupId playbackRate =
+    JE.object
+        [ ( "nodeGroupId", JE.int nodeGroupId )
+        , ( "action", JE.string "setPlaybackRate" )
+        , ( "playbackRate", JE.float playbackRate )
+        ]
+
+
+{-| A nonempty list of (time, volume) points for defining how loud a sound should be at any point in time.
+The points don't need to be sorted but don't include multiple points that have the same time.
+-}
+type alias VolumeTimeline =
+    Nonempty ( Time.Posix, Float )
+
+
+encodeSetVolumeAt : NodeGroupId -> List VolumeTimeline -> JE.Value
+encodeSetVolumeAt nodeGroupId volumeTimelines =
+    JE.object
+        [ ( "nodeGroupId", JE.int nodeGroupId )
+        , ( "action", JE.string "setVolumeAt" )
+        , ( "volumeAt", JE.list encodeVolumeTimeline volumeTimelines )
+        ]
+
+
+encodeVolumeTimeline : VolumeTimeline -> JE.Value
+encodeVolumeTimeline volumeTimeline =
+    volumeTimeline
+        |> Nonempty.toList
+        |> JE.list
+            (\( time, volume ) ->
+                JE.object
+                    [ ( "time", encodeTime time )
+                    , ( "volume", JE.float volume )
+                    ]
+            )
+
+
+encodeLoopConfig : Maybe LoopConfig -> JE.Value
+encodeLoopConfig maybeLoop =
+    case maybeLoop of
+        Just loop ->
+            JE.object
+                [ ( "loopStart", encodeDuration loop.loopStart )
+                , ( "loopEnd", encodeDuration loop.loopEnd )
+                ]
+
+        Nothing ->
+            JE.null
+
+
+flattenAudioCmd : AudioCmd msg -> List (AudioLoadRequest_ msg)
+flattenAudioCmd audioCmd =
+    case audioCmd of
+        AudioLoadRequest data ->
+            [ data ]
+
+        AudioCmdGroup list ->
+            List.map flattenAudioCmd list |> List.concat
+
+
+encodeAudioCmd : Model userMsg userModel -> AudioCmd userMsg -> ( Model userMsg userModel, JE.Value )
+encodeAudioCmd (Model model) audioCmd =
+    let
+        flattenedAudioCmd : List (AudioLoadRequest_ userMsg)
+        flattenedAudioCmd =
+            flattenAudioCmd audioCmd
+
+        newPendingRequests : List ( Int, AudioLoadRequest_ userMsg )
+        newPendingRequests =
+            flattenedAudioCmd |> List.indexedMap (\index request -> ( model.requestCount + index, request ))
+    in
+    ( { model
+        | requestCount = model.requestCount + List.length flattenedAudioCmd
+        , pendingRequests = Dict.union model.pendingRequests (Dict.fromList newPendingRequests)
+      }
+        |> Model
+    , newPendingRequests
+        |> List.map (\( index, value ) -> encodeAudioLoadRequest index value)
+        |> JE.list identity
+    )
+
+
+encodeAudioLoadRequest : Int -> AudioLoadRequest_ msg -> JE.Value
+encodeAudioLoadRequest index audioLoad =
+    JE.object
+        [ ( "audioUrl", JE.string audioLoad.audioUrl )
+        , ( "requestId", JE.int index )
+        ]
+
+
+type alias FlattenedAudio =
+    { source : Source
+    , startTime : Time.Posix
+    , startAt : Duration
+    , volume : Float
+    , volumeTimelines : List (Nonempty ( Time.Posix, Float ))
+    , loop : Maybe LoopConfig
+    , playbackRate : Float
+    }
+
+
+flattenAudio : Audio -> List FlattenedAudio
+flattenAudio audio_ =
+    case audio_ of
+        Group group_ ->
+            group_ |> List.map flattenAudio |> List.concat
+
+        BasicAudio { source, startTime, settings } ->
+            [ { source = source
+              , startTime = startTime
+              , startAt = settings.startAt
+              , volume = 1
+              , volumeTimelines = []
+              , loop = settings.loop
+              , playbackRate = settings.playbackRate
+              }
+            ]
+
+        Effect effect ->
+            case effect.effectType of
+                ScaleVolume scaleVolume_ ->
+                    List.map
+                        (\a -> { a | volume = scaleVolume_.scaleBy * a.volume })
+                        (flattenAudio effect.audio)
+
+                ScaleVolumeAt { volumeAt } ->
+                    List.map
+                        (\a -> { a | volumeTimelines = volumeAt :: a.volumeTimelines })
+                        (flattenAudio effect.audio)
+
+
+{-| Some kind of sound we want to play. To create `Audio` start with `audio`.
+-}
+type Audio
+    = Group (List Audio)
+    | BasicAudio { source : Source, startTime : Time.Posix, settings : PlayAudioConfig }
+    | Effect { effectType : EffectType, audio : Audio }
+
+
+{-| An effect we can apply to our sound such as changing the volume.
+-}
+type EffectType
+    = ScaleVolume { scaleBy : Float }
+    | ScaleVolumeAt { volumeAt : Nonempty ( Time.Posix, Float ) }
+
+
+{-| Audio data we can use to play sounds
+-}
+type Source
+    = File { bufferId : BufferId }
+
+
+audioSourceBufferId (File audioSource) =
+    audioSource.bufferId
+
+
+{-| Extra settings when playing audio from a file.
+
+    -- Here we play a song at half speed and it skips the first 15 seconds of the song.
+    audioWithConfig
+        { loop = Nothing
+        , playbackRate = 0.5
+        , startAt = Duration.seconds 15
+        }
+        myCoolSong
+        songStartTime
+
+-}
+type alias PlayAudioConfig =
+    { loop : Maybe LoopConfig
+    , playbackRate : Float
+    , startAt : Duration
+    }
+
+
+{-| Default config used for `audioWithConfig`.
+-}
+audioDefaultConfig : PlayAudioConfig
+audioDefaultConfig =
+    { loop = Nothing
+    , playbackRate = 1
+    , startAt = Quantity.zero
+    }
+
+
+{-| Control how audio loops. `loopEnd` defines where (relative to the start of the audio) the audio should loop and `loopStart` defines where it should loop to.
+
+    -- Here we have a song that plays an intro once and then loops between the 10 second point and the end of the song.
+    let
+        default =
+            Audio.audioDefaultConfig
+
+        -- This package doesn't support getting how long a sound plays for so we need to hard code it instead.
+        songLength =
+            Duration.seconds 120
+    in
+    audioWithConfig
+        { default | loop = Just { loopStart = Duration.seconds 10, loopEnd = songLength } }
+        coolBackgroundMusic
+        startTime
+
+-}
+type alias LoopConfig =
+    { loopStart : Duration, loopEnd : Duration }
+
+
+{-| Play audio from an audio source at a given time. This is the same as using `audioWithConfig audioDefaultConfig`.
+
+Note that in some browsers audio will be muted until user interacts with the webpage.
+
+-}
+audio : Source -> Time.Posix -> Audio
+audio source startTime =
+    audioWithConfig audioDefaultConfig source startTime
+
+
+{-| Play audio from an audio source at a given time with config.
+
+Note that in some browsers audio will be muted until user interacts with the webpage.
+
+-}
+audioWithConfig : PlayAudioConfig -> Source -> Time.Posix -> Audio
+audioWithConfig audioSettings source startTime =
+    BasicAudio { source = source, startTime = startTime, settings = audioSettings }
+
+
+{-| Scale how loud a given `Audio` is.
+1 preserves the current volume, 0.5 halves it, and 0 mutes it.
+If the the volume is less than 0, 0 will be used instead.
+-}
+scaleVolume : Float -> Audio -> Audio
+scaleVolume scaleBy audio_ =
+    Effect { effectType = ScaleVolume { scaleBy = max 0 scaleBy }, audio = audio_ }
+
+
+{-| Scale how loud some `Audio` is at different points in time.
+The volume will transition linearly between those points.
+The points in time don't need to be sorted but they need to be unique.
+
+    import Audio
+    import Duration
+    import Time
+
+
+    -- Here we define an audio function that fades in to full volume and then fades out until it's muted again.
+    --
+    --  1                ________
+    --                 /         \
+    --  0 ____________/           \_______
+    --     t ->    fade in     fade out
+    fadeInOut fadeInTime fadeOutTime audio =
+        Audio.scaleVolumeAt
+            [ ( Duration.subtractFrom fadeInTime Duration.second, 0 )
+            , ( fadeInTime, 1 )
+            , ( fadeOutTime, 1 )
+            , ( Duration.addTo fadeOutTime Duration.second, 0 )
+            ]
+            audio
+
+-}
+scaleVolumeAt : List ( Time.Posix, Float ) -> Audio -> Audio
+scaleVolumeAt volumeAt audio_ =
+    Effect
+        { effectType =
+            ScaleVolumeAt
+                { volumeAt =
+                    volumeAt
+                        |> Nonempty.fromList
+                        |> Maybe.withDefault (Nonempty.fromElement ( Time.millisToPosix 0, 1 ))
+                        |> Nonempty.map (Tuple.mapSecond (max 0))
+                        |> Nonempty.sortBy (Tuple.first >> Time.posixToMillis)
+                }
+        , audio = audio_
+        }
+
+
+{-| Combine multiple `Audio`s into a single `Audio`.
+-}
+group : List Audio -> Audio
+group audios =
+    Group audios
+
+
+{-| The sound of no sound at all.
+-}
+silence : Audio
+silence =
+    group []
+
+
+{-| Possible errors we can get when loading audio files.
+-}
+type LoadError
+    = MediaDecodeAudioDataUnknownContentType
+    | NetworkError
+    | ErrorThatHappensWhenYouLoadMoreThan1000SoundsDueToHackyWorkAroundToMakeThisPackageBehaveMoreLikeAnEffectPackage
+
+
+enumeratedResults : Nonempty (Result LoadError Source)
+enumeratedResults =
+    [ Err MediaDecodeAudioDataUnknownContentType, Err NetworkError ]
+        ++ (List.range 0 1000 |> List.map (\bufferId -> { bufferId = BufferId bufferId } |> File |> Ok))
+        |> Nonempty.Nonempty (Err ErrorThatHappensWhenYouLoadMoreThan1000SoundsDueToHackyWorkAroundToMakeThisPackageBehaveMoreLikeAnEffectPackage)
+
+
+{-| Load audio from a url.
+-}
+loadAudio : (Result LoadError Source -> msg) -> String -> AudioCmd msg
+loadAudio userMsg url =
+    AudioLoadRequest
+        { userMsg = Nonempty.map (\results -> ( results, userMsg results )) enumeratedResults
+        , audioUrl = url
+        }

--- a/examples/elm-audio/src/elm-audio.js
+++ b/examples/elm-audio/src/elm-audio.js
@@ -1,0 +1,210 @@
+function startAudio(app)
+{
+    window.AudioContext = window.AudioContext || window.webkitAudioContext || false;
+    if (window.AudioContext) {
+        let audioBuffers = []
+        let context = new AudioContext();
+        let audioPlaying = {};
+        /* https://lame.sourceforge.io/tech-FAQ.txt
+         * "All *decoders* I have tested introduce a delay of 528 samples. That
+         * is, after decoding an mp3 file, the output will have 528 samples of
+         * 0's appended to the front."
+         */
+        let mp3MarginInSamples = 528;
+
+        app.ports.martinsstewart_elm_audio_from_js.send({ type: 2, samplesPerSecond: context.sampleRate });
+
+        function loadAudio(audioUrl, requestId) {
+            let request = new XMLHttpRequest();
+            request.open('GET', audioUrl, true);
+
+            request.responseType = 'arraybuffer';
+
+            request.onerror = function() {
+                app.ports.martinsstewart_elm_audio_from_js.send({ type: 0, requestId: requestId, error: "NetworkError" });
+            }
+
+            // Decode asynchronously
+            request.onload = function() {
+                context.decodeAudioData(request.response, function(buffer) {
+                    let bufferId = audioBuffers.length;
+
+                    let isMp3 = audioUrl.endsWith(".mp3");
+                    // TODO: Read the header of the ArrayBuffer before decoding to an AudioBuffer https://www.mp3-tech.org/programmer/frame_header.html
+                    // need to use DataViews to read from the ArrayBuffer
+                    audioBuffers.push({ isMp3: isMp3, buffer: buffer });
+
+                    app.ports.martinsstewart_elm_audio_from_js.send({
+                        type: 1,
+                        requestId: requestId,
+                        bufferId: bufferId,
+                        durationInSeconds: (buffer.length - (isMp3 ? mp3MarginInSamples : 0)) / buffer.sampleRate
+                    });
+                }, function(error) {
+                    app.ports.martinsstewart_elm_audio_from_js.send({ type: 0, requestId: requestId, error: error.message });
+                });
+            }
+            request.send();
+        }
+
+        function posixToContextTime(posix, currentTimePosix) {
+            return (posix - currentTimePosix) / 1000 + context.currentTime;
+        }
+
+        function setLoop(sourceNode, loop, mp3MarginInSeconds) {
+            if (loop) {
+                sourceNode.loopStart = mp3MarginInSeconds + loop.loopStart / 1000;
+                sourceNode.loopEnd = mp3MarginInSeconds + loop.loopEnd / 1000;
+                sourceNode.loop = true;
+            }
+            else {
+                sourceNode.loop = false;
+            }
+        }
+
+        function createVolumeTimelineGainNodes(volumeAt, currentTime) {
+            return volumeAt.map(volumeTimeline => {
+                let gainNode = context.createGain();
+
+                gainNode.gain.setValueAtTime(volumeTimeline[0].volume, 0);
+                gainNode.gain.linearRampToValueAtTime(
+                    volumeTimeline[0].volume,
+                    posixToContextTime(volumeTimeline[0].time, currentTime));
+
+                for (let j = 1; j < volumeTimeline.length; j++) {
+                    let timeAndValue = volumeTimeline[j];
+                    let previous = volumeTimeline[j-1];
+                    let contextTime = posixToContextTime(timeAndValue.time, currentTime);
+                    if (contextTime >= context.currentTime && previous.contextTime < context.currentTime) {
+                        let t = (context.currentTime - previous.contextTime) / (contextTime - previous.contextTime);
+                        let volume = t * (timeAndValue.volume - previous.volume) + previous.volume;
+
+                        if (isFinite(volume)) {
+                            gainNode.gain.setValueAtTime(volume, 0);
+                        }
+                    }
+                    else if (contextTime >= context.currentTime) {
+                        gainNode.gain.linearRampToValueAtTime(timeAndValue.volume, contextTime);
+                    }
+                    else {
+                        gainNode.gain.setValueAtTime(timeAndValue.volume, 0);
+                    }
+                    previous = { contextTime: contextTime, volume: timeAndValue.volume };
+                }
+
+                return gainNode;
+            });
+        }
+
+        function connectNodes(nodes) {
+            for (let j = 1; j < nodes.length; j++) {
+                nodes[j-1].connect(nodes[j]);
+            }
+        }
+
+        function playSound(audioBuffer, volume, volumeTimelines, startTime, startAt, currentTime, loop, playbackRate) {
+            let buffer = audioBuffer.buffer;
+            let mp3MarginInSeconds = audioBuffer.isMp3
+                ? mp3MarginInSamples / context.sampleRate
+                : 0;
+            let source = context.createBufferSource();
+            source.buffer = buffer;
+            source.playbackRate.value = playbackRate;
+            setLoop(source, loop, mp3MarginInSeconds);
+
+            let timelineGainNodes = createVolumeTimelineGainNodes(volumeTimelines, currentTime);
+
+            let gainNode = context.createGain();
+            gainNode.gain.setValueAtTime(volume, 0);
+
+            connectNodes([source, gainNode, ...timelineGainNodes, context.destination]);
+
+            if (startTime >= currentTime) {
+                source.start(posixToContextTime(startTime, currentTime), mp3MarginInSeconds + startAt / 1000);
+            }
+            else {
+                // TODO: offset should account for looping
+                let offset = (currentTime - startTime) / 1000;
+                source.start(0, offset + mp3MarginInSeconds + startAt / 1000);
+            }
+
+            return { sourceNode: source, gainNode: gainNode, volumeAtGainNodes: timelineGainNodes };
+        }
+
+        app.ports.martinsstewart_elm_audio_to_js.subscribe( ( message ) => {
+            let currentTime = new Date().getTime();
+            for (let i = 0; i < message.audio.length; i++) {
+                let audio = message.audio[i];
+                switch (audio.action)
+                {
+                    case "stopSound":
+                    {
+                        let value = audioPlaying[audio.nodeGroupId];
+                        audioPlaying[audio.nodeGroupId] = null;
+                        value.nodes.sourceNode.stop();
+                        value.nodes.sourceNode.disconnect();
+                        value.nodes.gainNode.disconnect();
+                        value.nodes.volumeAtGainNodes.map(node => node.disconnect());
+                        break;
+                    }
+                    case "setVolume":
+                    {
+                        let value = audioPlaying[audio.nodeGroupId];
+                        value.nodes.gainNode.gain.setValueAtTime(audio.volume, 0);
+                        break;
+                    }
+                    case "setVolumeAt":
+                    {
+                        let value = audioPlaying[audio.nodeGroupId];
+                        value.nodes.volumeAtGainNodes.map(node => node.disconnect());
+                        value.nodes.gainNode.disconnect();
+
+                        let newGainNodes = createVolumeTimelineGainNodes(audio.volumeAt, currentTime);
+
+                        connectNodes([value.nodes.gainNode, ...newGainNodes, context.destination]);
+
+                        value.nodes.volumeAtGainNodes = newGainNodes;
+                        break;
+                    }
+                    case "setLoopConfig":
+                    {
+                        let value = audioPlaying[audio.nodeGroupId];
+                        let audioBuffer = audioBuffers[value.bufferId];
+                        let mp3MarginInSeconds = audioBuffer.isMp3
+                            ? mp3MarginInSamples / context.sampleRate
+                            : 0;
+                        setLoop(value.nodes.sourceNode, value.loop, mp3MarginInSeconds);
+                        break;
+                    }
+                    case "setPlaybackRate":
+                    {
+                        let value = audioPlaying[audio.nodeGroupId];
+                        value.nodes.sourceNode.playbackRate.setValueAtTime(audio.playbackRate, 0);
+                        break;
+                    }
+                    case "startSound":
+                    {
+                        let nodes = playSound(
+                            audioBuffers[audio.bufferId],
+                            audio.volume,
+                            audio.volumeTimelines,
+                            audio.startTime,
+                            audio.startAt,
+                            currentTime,
+                            audio.loop,
+                            audio.playbackRate);
+                        audioPlaying[audio.nodeGroupId] = { bufferId: audio.bufferId, nodes: nodes };
+                        break;
+                    }
+                }
+            }
+
+            for (let i = 0; i < message.audioCmds.length; i++) {
+                loadAudio(message.audioCmds[i].audioUrl, message.audioCmds[i].requestId);
+            }
+        });
+    }
+    else {
+        console.log("Web audio is not supported in your browser.");
+    }
+}


### PR DESCRIPTION
I've copied over the elm-audio package code. I've left out the tests and example folder and I've updated the port names (they were called audioPortToJS and audioPortFromJS before).