### PR TITLE
Remove unsafe async from port subscription registration.

### DIFF
--- a/examples/copy-to-clipboard/src/copy-to-clipboard.js
+++ b/examples/copy-to-clipboard/src/copy-to-clipboard.js
@@ -2,8 +2,8 @@
 port supermario_copy_to_clipboard_to_js : String -> Cmd msg
 */
 
-exports.init = async function(app) {
-  app.ports.supermario_copy_to_clipboard_to_js.subscribe(function(text) {
+exports.init = function(app) {
+  app.ports.supermario_copy_to_clipboard_to_js.subscribe(async function(text) {
     copyTextToClipboard(text)
   })
 }


### PR DESCRIPTION
A minor but important note. If ports aren't registered immediately it can cause issues. So the code to register the port handlers needs to be synchronous. The callback to handle the port is where the async should be.